### PR TITLE
Support for 'events' in highlighting and snippets: Issue #807

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer-support-client",
   "displayName": "Hyyperledger Composer",
-  "description": "Hyyperledger Composer syntax highlighting, autocomplete & error checking",
+  "description": "Hyyperledger Composer syntax highlighting, autocomplete, snippets & error checking",
   "author": "Hyperledger Composer",
   "license": "Apache-2.0",
   "version": "0.7.0",
@@ -49,7 +49,7 @@
       {
         "id": "composer",
         "aliases": [
-          "Hyperledger-Composer",
+          "Hyperledger Composer",
           "Composer"
         ],
         "extensions": [

--- a/client/snippets/composer.json
+++ b/client/snippets/composer.json
@@ -26,6 +26,15 @@
 		],
 		"description": "Composer Transaction"
 	},
+  "event": {
+		"prefix": "event",
+		"body": [
+			"event ${1:eventName} identified by ${2:eventKey} {",
+			"\to String ${2}$0",
+			"}"
+		],
+		"description": "Composer Event"
+	},
 	"concept": {
 		"prefix": "concept",
 		"body": [

--- a/client/syntaxes/composer.tmLanguage.json
+++ b/client/syntaxes/composer.tmLanguage.json
@@ -57,7 +57,7 @@
 		},
 	  "composer-declaration": {
 			"name": "keyword.control.flow.composer",
-			"match": "\\b(asset|transaction|participant|enum|concept)\\b",
+			"match": "\\b(asset|transaction|participant|enum|concept|event)\\b",
 			"patterns": []
 		},
 		"composer-abstract-type": {


### PR DESCRIPTION
This is the fix for issue #807 ("As a user I can edit event definitions in VSCode")