### PR TITLE
Support new Composer Query Syntax Parsing

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,13 +1,14 @@
 # Hyperledger Composer Extension for VSCode 
 
-Validate Composer model files that define the structure of your business network 
+Validate Composer models that define the structure of your business network 
 in terms of Assets, Participants and Transactions.
 
-This VSCode extension parses .cto files using the Hyperledger Composer parser
+This VSCode extension parses '.cto' files using the Hyperledger Composer parser
 and reports any validation errors. It will also parse and validate Hyperledger
-Composer "permissions.acl" files. To work with models that use imports and span 
-multiple files, you must open all related files. To validate the ACL file, the 
-corresponding model files must also be opened.
+Composer 'permissions.acl' files and query files ('.qry'). To work with models 
+that use imports and span multiple files, you must open all related files. 
+To validate the ACL file and the query files, the corresponding model files 
+must also be opened.
 
 This extention is currently in beta so please raise any problems you find as an 
 [issue](https://github.com/hyperledger/composer-vscode-plugin/issues).

--- a/client/composer-qry.language-configuration.json
+++ b/client/composer-qry.language-configuration.json
@@ -1,0 +1,18 @@
+{
+	"comments": {
+		"lineComment": "//",
+		"blockComment": [ "/*", "*/" ]
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{",  "close": "}",  "notIn": ["string"] },
+		{ "open": "[",  "close": "]",  "notIn": ["string"] },
+		{ "open": "(",  "close": ")",  "notIn": ["string"] },
+		{ "open": "'",  "close": "'",  "notIn": ["string"] },
+		{ "open": "\"", "close": "\"", "notIn": ["string", "comment"] }
+	]
+}

--- a/client/config/default.json
+++ b/client/config/default.json
@@ -1,0 +1,18 @@
+{
+	"composer": {
+		"debug": {
+			"logger": "./winstonInjector.js",
+			"config": {
+				"console": {
+					"enabledLevel": "info",
+					"alwaysLevel": "none"
+				},
+				"file": {
+					"filename": "trace_PID.log",
+					"enabledLevel": "error",
+					"alwaysLevel": "error"
+				}
+			}
+		}
+	}
+}

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "description": "Hyperledger Composer syntax highlighting, autocomplete, snippets & error checking",
   "author": "Hyperledger Composer",
   "license": "Apache-2.0",
-  "version": "0.8.2",
+  "version": "0.9.1",
   "publisher": "HyperledgerComposer",
   "icon": "icon.png",
   "engines": {
@@ -30,14 +30,24 @@
         "editor.quickSuggestions": true,
         "editor.insertSpaces": true,
         "editor.tabSize": 2,
-        "editor.snippetSuggestions": "top"
+        "editor.snippetSuggestions": "top",
+        "editor.detectIndentation": false
       },
       "[composer-acl]": {
         "editor.wordWrap": "on",
         "editor.quickSuggestions": true,
         "editor.insertSpaces": true,
         "editor.tabSize": 2,
-        "editor.snippetSuggestions": "top"
+        "editor.snippetSuggestions": "top",
+        "editor.detectIndentation": false
+      },
+      "[composer-qry]": {
+        "editor.wordWrap": "on",
+        "editor.quickSuggestions": true,
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2,
+        "editor.snippetSuggestions": "top",
+        "editor.detectIndentation": false
       }
     },
     "configuration": {
@@ -82,6 +92,16 @@
           "permissions.acl"
         ],
         "configuration": "./composer-acl.language-configuration.json"
+      },
+      {
+        "id": "composer-qry",
+        "aliases": [
+          "Hyperledger Composer Query"
+        ],
+        "extensions": [
+          ".qry"
+        ],
+        "configuration": "./composer-qry.language-configuration.json"
       }
     ],
     "grammars": [
@@ -94,6 +114,11 @@
         "language": "composer-acl",
         "scopeName": "source.composer.acl",
         "path": "./syntaxes/composer-acl.tmLanguage.json"
+      },
+      {
+        "language": "composer-qry",
+        "scopeName": "source.composer.qry",
+        "path": "./syntaxes/composer-qry.tmLanguage.json"
       }
     ],
     "snippets": [
@@ -104,6 +129,10 @@
       {
         "language": "composer-acl",
         "path": "./snippets/composer-acl.json"
+      },
+      {
+        "language": "composer-qry",
+        "path": "./snippets/composer-qry.json"
       }
     ]
   },

--- a/client/snippets/composer-qry.json
+++ b/client/snippets/composer-qry.json
@@ -1,0 +1,15 @@
+{
+	"BasicQuery": {
+		"prefix": "Basic Composer Query",
+		"body": [
+			"query ${1:BasicQueryName} {",
+			"\tdescription: \"${2:Description of the Basic Query}\"",
+			"\tstatement: ",
+			"\t\tSELECT ${3:org.acme.sample.user}",
+			"\t\tWHERE (${4:name == 'Bob'})",
+			"}",
+			"$0"
+		],
+		"description": "Basic Composer Query"
+	}
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: ExtensionContext) {
   // Options to control the composer validator client
   let clientOptions: LanguageClientOptions = {
     // Register the server for composer documents
-    documentSelector: ['composer','composer-acl'],
+    documentSelector: ['composer','composer-acl','composer-qry'],
     synchronize: {
       // Synchronize the setting section 'Composer' to the server
       configurationSection: 'composer',
@@ -48,7 +48,10 @@ export function activate(context: ExtensionContext) {
       return;
     }
 
-    if ((editor.document.languageId != "composer") && (editor.document.languageId != "composer-acl")) {
+    //make sure it is one of the languages we care about
+    if ((editor.document.languageId != "composer")     && 
+        (editor.document.languageId != "composer-acl") &&
+        (editor.document.languageId != "composer-qry")    ) {
       return;
     }
 

--- a/client/syntaxes/composer-acl.tmLanguage.json
+++ b/client/syntaxes/composer-acl.tmLanguage.json
@@ -28,7 +28,7 @@
     },
     "rule": {
       "name": "keyword.control.flow.composer-acl",
-      "match": "\\b(rule)\\b(.*)\\b",
+      "match": "\\b(rule)\\s+(\\w+)",
       "captures": {
         "1": {
           "name": "keyword.control.flow.composer-acl"
@@ -37,7 +37,11 @@
           "name": "variable.other.composer-acl"
         }
       },
-      "patterns": []
+      "patterns": [
+        {
+          "include": "#comment"
+        }
+      ]
     },
     "object": {
       "begin": "\\{",
@@ -54,6 +58,9 @@
       ],
       "name": "meta.structure.dictionary.composer-acl",
       "patterns": [
+        {
+          "include": "#comment"
+        },
         {
           "comment": "the composer-acl object key",
           "include": "#objectkey"
@@ -77,6 +84,9 @@
           "name": "meta.structure.dictionary.value.composer-acl",
           "patterns": [
             {
+              "include": "#comment"
+            },
+            {
               "comment": "the composer-acl object value",
               "include": "#objectvalue"
             }
@@ -90,6 +100,9 @@
     },
     "objectkey": {
       "patterns": [
+        {
+          "include": "#comment"
+        },
         {
           "include": "#definition"
         },
@@ -125,6 +138,9 @@
       "name": "storage.type.property.composer-acl",
       "patterns": [
         {
+          "include": "#comment"
+        },
+        {
           "include": "#simpleDefinitions"
         },
         {
@@ -135,12 +151,20 @@
     "simpleDefinitions": {
       "match": "\\b(description|operation|action)\\b",
       "name": "storage.type.property.composer-acl",
-      "patterns": []
+      "patterns": [
+        {
+          "include": "#comment"
+        }
+      ]
     },
     "complexDefinitions": {
       "match": "\\b(participant|resource|condition|transaction)\\b",
       "name": "storage.type.property.composer-acl",
-      "patterns": []
+      "patterns": [
+        {
+          "include": "#comment"
+        }
+      ]
     },
     "objectvalue": {
       "patterns": [
@@ -224,7 +248,7 @@
       ]
     },
     "path": {
-      "match": "(\\w+)|(\\.|#)",
+      "match": "(\\w+)|(\\.|\\*|#)",
       "captures": {
         "1": {
           "name": "variable.other.object.composer-acl"

--- a/client/syntaxes/composer-qry.tmLanguage.json
+++ b/client/syntaxes/composer-qry.tmLanguage.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Hyperledger Composer Query Support",
+  "displayName": "Hyperledger Composer Query",
+  "scopeName": "source.composer.qry",
+  "fileTypes": [
+    ".qry"
+  ],
+  "uuid": "805375ec-d614-41f5-8993-5843fe63eb67",
+  "patterns": [
+    {
+      "include": "#statements"
+    }
+  ],
+  "repository": {
+    "statements": {
+      "patterns": [
+        {
+          "include": "#query"
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#object"
+        }
+      ]
+    },
+    "query": {
+      "name": "keyword.control.flow.composer-qry",
+      "begin": "\\b(query)(\\s+)(\\w+)",
+      "end": "(?=\\{)",
+      "captures": {
+        "1": {
+          "name": "keyword.control.flow.composer-qry"
+        },
+        "2": {
+          "name": "variable.other.composer-qry"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "object": {
+      "begin": "\\{",
+      "beginCaptures": [
+        {
+          "name": "punctuation.definition.dictionary.begin.composer-qry"
+        }
+      ],
+      "end": "\\}",
+      "endCaptures": [
+        {
+          "name": "punctuation.definition.dictionary.end.composer-qry"
+        }
+      ],
+      "name": "meta.structure.dictionary.composer-qry",
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "comment": "the composer-qry object key",
+          "include": "#objectkey"
+        },
+        {
+          "begin": ":",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.dictionary.key-value.composer-qry"
+            }
+          },
+          "end": "(?=\\})",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.separator.dictionary.pair.composer-qry"
+            }
+          },
+          "name": "meta.structure.dictionary.value.composer-qry",
+          "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "comment": "the composer-qry object value",
+              "include": "#objectvalue"
+            }
+          ]
+        },
+        {
+          "match": "[^\\s\\}]",
+          "name": "invalid.illegal.expected-dictionary-separator.composer-qry"
+        }
+      ]
+    },
+    "objectkey": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#definition"
+        },
+        {
+          "include": "#embeddedSQL"
+        }
+      ]
+    },
+    "string": {
+      "begin": "\"",
+      "beginCaptures": [
+        {
+          "name": "punctuation.definition.string.begin.composer-qry"
+        }
+      ],
+      "end": "\"",
+      "endCaptures": [
+        {
+          "name": "punctuation.definition.string.composer-qry"
+        }
+      ],
+      "name": "string.quoted.double.composer-qry",
+      "patterns": []
+    },
+    "definition": {
+      "name": "storage.type.property.composer-qry",
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#simpleDefinitions"
+        },
+        {
+          "include": "#complexDefinitions"
+        }
+      ]
+    },
+    "simpleDefinitions": {
+      "match": "\\b(description)\\b",
+      "name": "storage.type.property.composer-qry",
+      "patterns": [
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "complexDefinitions": {
+      "match": "\\b(statement)\\b",
+      "name": "storage.type.property.composer-qry",
+      "patterns": [
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "objectvalue": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#definition"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#embeddedSQL"
+        }
+      ]
+    },
+    "embeddedSQL": {
+      "begin": "(?=SELECT)",
+      "end": "(?=\\})",
+      "name": "meta.structure.dictionary.composer-qry",
+      "patterns": [
+        {
+          "comment": "Embedded SQL",
+          "include": "source.sql"
+        }
+      ]
+    },
+    "comment": {
+      "patterns": [
+        {
+          "name": "comment.block.documentation.js",
+          "begin": "/\\*\\*(?!/)",
+          "end": "\\*/",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.js"
+            }
+          },
+          "patterns": []
+        },
+        {
+          "name": "comment.block.js",
+          "begin": "/\\*",
+          "end": "\\*/",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.js"
+            }
+          }
+        },
+        {
+          "begin": "(^[ \\t]+)?(?=//)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.js"
+            }
+          },
+          "end": "(?=$)",
+          "patterns": [
+            {
+              "name": "comment.line.double-slash.js",
+              "begin": "//",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.js"
+                }
+              },
+              "end": "(?=$)"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/client/syntaxes/composer-qry.tmLanguage.json
+++ b/client/syntaxes/composer-qry.tmLanguage.json
@@ -34,7 +34,7 @@
         "1": {
           "name": "keyword.control.flow.composer-qry"
         },
-        "2": {
+        "3": {
           "name": "variable.other.composer-qry"
         }
       },


### PR DESCRIPTION
Support for new ".qry" file type (single file support to mirror composer base).
Supports syntax highlighting and validation etc using the composer-common 0.9.0 parser
Supports Query snippets to show simple usage example