### PR TITLE
Bump Composer and extension to v0.19.12

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
   ],
   "homepage": "https://hyperledger.github.io/composer/",
   "license": "Apache-2.0",
-  "version": "0.19.8",
+  "version": "0.19.12",
   "publisher": "HyperledgerComposer",
   "icon": "icon.png",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "composer-support-server",
   "description": "HyperledgerComposer server",
-  "version": "0.19.8",
+  "version": "0.19.12",
   "author": "Hyperledger Composer",
   "publisher": "HyperledgerComposer",
   "license": "Apache-2.0",
@@ -13,7 +13,7 @@
     "url": "https://github.com/hyperledger/composer-vscode-plugin"
   },
   "dependencies": {
-    "composer-common": "0.19.8",
+    "composer-common": "0.19.12",
     "vscode-languageserver": "3.3.0",
     "vscode-uri": "1.0.1"
   },


### PR DESCRIPTION
https://github.com/hyperledger/composer/issues/4235

New modelling language features introduced in Composer v0.19.12 need to be pushed into the Visual Studio Code extension.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>