### PR TITLE
Remove extra copies of Apache 2 license

### DIFF
--- a/markdown-license.txt
+++ b/markdown-license.txt
@@ -1,2 +1,0 @@
-## License <a name="license"></a>
-Hyperledger Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the [LICENSE](LICENSE.txt) file. Hyperledger Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
Signed-off-by: Ry Jones <ry@linux.com>